### PR TITLE
Update to browserSync.js

### DIFF
--- a/gulp/tasks/browserSync.js
+++ b/gulp/tasks/browserSync.js
@@ -13,16 +13,7 @@ gulp.task('browserSync', function() {
   browserSync.init({
     server: {
       baseDir: config.buildDir,
-      middleware: function(req, res, next) {
-        let fileHrefArray = url.parse(req.url).href.split('.');
-        let fileExtension = fileHrefArray[fileHrefArray.length - 1];
-
-        if ( ASSET_EXTENSIONS.indexOf(fileExtension) === -1 ) {
-          req.url = '/' + DEFAULT_FILE;
-        }
-
-        return next();
-      }
+      index: DEFAULT_FILE
     },
     port: config.browserPort,
     ui: {


### PR DESCRIPTION
Was having issues with browsersync seding my main.css file as a text/html content type. After looking into it found it was an issue with the middle ware. So i replaced the middleware with index: DEFAULT_FILE and it worked. The index parameter also did exactly what the middleware was doing anyway.