### PR TITLE
gulp browser-sync css injection bug fix

### DIFF
--- a/gulp/tasks/browserSync.js
+++ b/gulp/tasks/browserSync.js
@@ -15,7 +15,7 @@ gulp.task('browserSync', function() {
       baseDir: config.buildDir,
       middleware: function(req, res, next) {
         let fileHrefArray = url.parse(req.url).href.split('.');
-        let fileExtension = fileHrefArray[fileHrefArray.length - 1];
+        let fileExtension = fileHrefArray[fileHrefArray.length - 1].split("?")[0].split("#")[0];
 
         if ( ASSET_EXTENSIONS.indexOf(fileExtension) === -1 ) {
           req.url = '/' + DEFAULT_FILE;


### PR DESCRIPTION
Fixes issue with browser-sync css injection by trimming the query
string from the fileExtension. Also extended this to trim hashes that
could potentially be equally problematic.

see pull request #23 