### PR TITLE
Use gulp-sourcemaps to provide sass source maps

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -31,6 +31,7 @@ const config = {
   assetExtensions: [
     'js',
     'css',
+    'map',
     'png',
     'jpe?g',
     'gif',

--- a/gulp/tasks/sass.js
+++ b/gulp/tasks/sass.js
@@ -3,6 +3,7 @@
 import gulp         from 'gulp';
 import sass         from 'gulp-sass';
 import gulpif       from 'gulp-if';
+import sourcemaps   from 'gulp-sourcemaps';
 import browserSync  from 'browser-sync';
 import autoprefixer from 'gulp-autoprefixer';
 import handleErrors from '../util/handle-errors';
@@ -11,13 +12,14 @@ import config       from '../config';
 gulp.task('sass', function() {
 
   return gulp.src(config.styles.src)
+    .pipe(gulpif(!global.isProd, sourcemaps.init()))
     .pipe(sass({
       sourceComments: global.isProd ? false : 'map',
-      sourceMap: global.isProd ? false : 'sass',
       outputStyle: global.isProd ? 'compressed' : 'nested'
     }))
     .on('error', handleErrors)
     .pipe(autoprefixer('last 2 versions', '> 1%', 'ie 8'))
+    .pipe(gulpif(!global.isProd, sourcemaps.write('.')))
     .pipe(gulp.dest(config.styles.dest))
     .pipe(gulpif(browserSync.active, browserSync.reload({ stream: true })));
 


### PR DESCRIPTION
gulp-sass/node-sass was not creating the source map, preventing browsers from loading the stylesheet correctly.